### PR TITLE
Use C++ API for FONT_HERSHEY_COMPLEX

### DIFF
--- a/src/linedetect.cpp
+++ b/src/linedetect.cpp
@@ -91,7 +91,7 @@ int LineDetect::colorthresh(cv::Mat input) {
   rectangle(input, pt1, pt2, CV_RGB(255, 0, 0), 2);
   // Inserting text box
   cv::putText(input, "Line Detected", pt3,
-    CV_FONT_HERSHEY_COMPLEX, 1, CV_RGB(255, 0, 0));
+    cv::FONT_HERSHEY_COMPLEX, 1, CV_RGB(255, 0, 0));
   }
   // Mask image to limit the future turns affecting the output
   img_mask(cv::Rect(0.7*w, 0, 0.3*w, h)) = 0;


### PR DESCRIPTION
Otherwise `catkin_make` triggers the following error:

```
catkin_ws/src/line_follower_turtlebot/src/linedetect.cpp:94:5: error: ‘CV_FONT_HERSHEY_COMPLEX’ was not declared in this scope
   94 |     CV_FONT_HERSHEY_COMPLEX, 1, CV_RGB(255, 0, 0));
      |     ^~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [line_follower_turtlebot/CMakeFiles/detect.dir/build.make:76: line_follower_turtlebot/CMakeFiles/detect.dir/src/linedetect.cpp.o] Error 1
```